### PR TITLE
adds support for defining fixed-case words in the dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ FALSE <-> TRUE
 …
 ```
 
+Words surrounded with double curly braces `{{  }}` are replaced exactly as they are defined in the dictionary.
+
+Definition in dictionary:
+
+```
+{{PhantomJS}} <-> {{Chrome}}
+```
+
+Usage:
+
+```javascript
+module.exports = function (karma) {
+    karma.set({
+		browsers: ['PhantomJS'], /* <-> Chrome */
+    });
+}
+```
+
 
 Usage
 -----
@@ -35,7 +53,7 @@ Installation
 
 or
 
-1. Open you Sublime Text 2 Packages directory
+1. Open you Sublime Text 3 Packages directory
 2. Run `git clone git://github.com/gordio/ToggleBool`
 3. Have fun!
 
@@ -57,7 +75,10 @@ Example file `ToggleWord.sublime-settings`
 		"left":	"right",
 		"top":	"bottom",
 		"up":	"down",
-		"width": "height"
+		"width": "height",
+		"{{PhantomJS}}": "{{Chrome}}"
 	}
 }
 ```
+
+If installed using `Package Control` dictionary file should be located in in `<data_path>/Packages`. To get there select `Prefences -> Browse Packages...` in Sublime menu.

--- a/ToggleWord.py
+++ b/ToggleWord.py
@@ -19,6 +19,21 @@ class ToggleBoolCommand(sublime_plugin.TextCommand):
 		editor_word = self.view.substr(region)
 
 		for word_item in words_dict:
+			# PhantomJS <> Chrome
+			# For case when letter cases are mixed
+			# Words defined in the dictionary surrounded with "{{ }}" are
+			# replaced as they are, without modifying their case
+			if word_item[0].startswith('{{') and word_item[0].endswith('}}'):
+				stripped_word = word_item[0].strip('{}');
+				if editor_word == stripped_word:
+					self.view.replace(view, region, word_item[1].strip('{}'))
+					return
+			if word_item[1].startswith('{{') and word_item[1].endswith('}}'):
+				stripped_word = word_item[1].strip('{}');
+				if editor_word == stripped_word:
+					self.view.replace(view, region, word_item[0].strip('{}'))
+					return
+
 			# true <> false
 			# For case when all letters are lowercase
 			if editor_word == word_item[0].lower():
@@ -45,7 +60,7 @@ class ToggleBoolCommand(sublime_plugin.TextCommand):
 			if editor_word == word_item[1].upper():
 				self.view.replace(view, region, word_item[0].upper())
 				return
-				
+
 		# Word not found? Show message
 		sublime.status_message(
 			"{0}: Can't find toggles for '{1}'".format(

--- a/ToggleWord.sublime-settings
+++ b/ToggleWord.sublime-settings
@@ -1,9 +1,10 @@
 {
-	// User defined words
-	"toggle_word_dict": {
-		"left":	"right",
-		"top":	"bottom",
-		"up":	"down",
-		"width": "height"
-	}
+    // User defined words
+    "toggle_word_dict": {
+        "left": "right",
+        "top": "bottom",
+        "up": "down",
+        "width": "height",
+        "{{PhantomJS}}": "{{Chrome}}"
+    }
 }


### PR DESCRIPTION
Dictionary words defined in double curly braces are searched and
replaced as they are, without altering their case.

E.g.:

```
{{PhantomJS}} <-> {{Chrome}}
```
