### PR TITLE
Improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Example file `ToggleWords.sublime-settings`:
 ```
 {
     // User defined words
-    "toggle_word_dict": [
+    "toggle_words_dict": [
         ["left", "right"],
         ["up", "down"],
         ["top", "bottom"],

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#About
+# About
 
 Plugin for Sublime Text 3 - toggle words with support for user defined arrays.
 
@@ -21,12 +21,15 @@ False <-> True
 FALSE <-> TRUE
 ```
 
-#Usage
+# Usage
 
-Set cursor on word or select word and press <kbd>Cmd</kbd>+<kbd>Alt</kbd>+<kbd>x</kbd> (OS X), <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>x</kbd> (Windows) or <kbd>Super</kbd>+<kbd>Alt</kbd>+<kbd>x</kbd> (Linux).
+Set cursor on word or select word and press:
+* <kbd>Cmd</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd> (OS X)
+* <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd> (Windows)
+* <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>X</kbd> (Linux)
 
 
-#Installation
+# Installation
 
 0. Install Package Control
 1. Open ST command panel (<kbd>Shift</kbd>+<kbd>Control</kbd>+<kbd>P</kbd>), choose `Package Control — Install Package`, type `Toggle`, find Toggle Words and press <kbd>Enter</kbd>
@@ -39,7 +42,7 @@ or
 3. Have fun!
 
 
-#Configure
+# Configure
 
 ## Keys
 


### PR DESCRIPTION
I had trouble updating my user dictionary until I realized that I had copied the example from the README file, and that example was out of date. Here is the correction. This should resolve issue #13, as I think the OP there had the same issue.

I fixed the Markdown syntax. It was rendering correctly on Package Control, but not on GitHub.

I corrected the documented Linux keyboard shortcut to match what is in the `Default (Linux).sublime-keymap` file. That file also agrees with my testing on Linux.

Thanks for a great package!